### PR TITLE
Enable redirect after login

### DIFF
--- a/admin/cb-users/class-cb-users.php
+++ b/admin/cb-users/class-cb-users.php
@@ -195,7 +195,7 @@ class CB_Users extends Commons_Booking {
 
   public function cb_login_redirect( $redirect_to, $request, $user ) {
       //is there a user to check?
-      global $user, $_SERVER;
+      global $user;
       if ( isset( $user->roles ) && is_array( $user->roles ) ) {
           //check for admins
           if ( in_array( 'administrator', $user->roles ) ) {

--- a/admin/cb-users/class-cb-users.php
+++ b/admin/cb-users/class-cb-users.php
@@ -195,15 +195,15 @@ class CB_Users extends Commons_Booking {
 
   public function cb_login_redirect( $redirect_to, $request, $user ) {
       //is there a user to check?
-      global $user;
+      global $user, $_SERVER;
       if ( isset( $user->roles ) && is_array( $user->roles ) ) {
           //check for admins
           if ( in_array( 'administrator', $user->roles ) ) {
               // redirect them to the default place
               return $redirect_to;
-          } 
-        }
-        return home_url();
+          }
+      }
+      return isset( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : home_url();
   }
 
     /*


### PR DESCRIPTION
Redirect after login with URL parameter '?redirect_to=' was not working. The parameter is now checked for and is respected. This enables visiting the page {{BASE_URL}}/wp-admin/profile.php when not yet logged in, logging in, then being redirected to the correct page. See also https://stackoverflow.com/questions/20356880/wordpress-login-redirect-to-not-working. Credits to Stefan Meretz (Bolle Bonn) for implementing this.