### PR TITLE
rename cb_get_template_part into cb1_get_template_part

### DIFF
--- a/admin/cb-users/class-cb-users.php
+++ b/admin/cb-users/class-cb-users.php
@@ -367,7 +367,7 @@ class CB_Users extends Commons_Booking {
         $current_user = wp_get_current_user();
         $template_vars = cb_object_to_array ( $current_user );
 
-        $content .= cb_get_template_part( 'user-bar', $template_vars, TRUE ); // include user bar
+        $content .= cb1_get_template_part( 'user-bar', $template_vars, TRUE ); // include user bar
 
         $user_bookings = $this->get_user_bookings( $current_user->ID );
 
@@ -382,7 +382,7 @@ class CB_Users extends Commons_Booking {
             );
 
 
-          $content .= cb_get_template_part( 'user-bookings', $template_vars, TRUE ); 
+          $content .= cb1_get_template_part( 'user-bookings', $template_vars, TRUE ); 
 
         } else {
           $content .= __( 'You haven´t booked anything yet.', 'commons-booking'); 

--- a/includes/template.php
+++ b/includes/template.php
@@ -44,7 +44,7 @@ function commons_booking_get_template_part( $slug, $name = '', $include = true )
 	}
 }
 
-function cb_get_template_part( $template = '', $attributes = null, $buffer = FALSE ) {
+function cb1_get_template_part( $template = '', $attributes = null, $buffer = FALSE ) {
 	$path = plugin_dir_path( realpath( dirname( __FILE__ ) ) ) . 'templates/';
 	$plugin = Commons_Booking::get_instance();
 	$plugin_slug = $plugin->get_plugin_slug();

--- a/public/cb-bookings/class-cb-booking-comments.php
+++ b/public/cb-bookings/class-cb-booking-comments.php
@@ -76,7 +76,7 @@ class CB_Booking_Comments {
       $args = array (
         'comment' => $comments[0]->comment_content
         );
-      cb_get_template_part('booking-review-booking-comment', $args);
+      cb1_get_template_part('booking-review-booking-comment', $args);
 
     } else { // No comment, show form
 

--- a/public/cb-bookings/class-cb-booking.php
+++ b/public/cb-bookings/class-cb-booking.php
@@ -687,7 +687,7 @@ public function get_booked_days_array( $item_id, $comments, $status= 'confirmed'
                     $this->booking_id = $this->create_booking( $this->date_start, $this->date_end, $this->item_id);
                     $this->set_booking_vars();
 
-                    return cb_display_message( $msg, $this->b_vars ) . cb_get_template_part( 'booking-review', $this->b_vars , true ) . cb_get_template_part( 'booking-review-submit', $this->b_vars , true );
+                    return cb_display_message( $msg, $this->b_vars ) . cb1_get_template_part( 'booking-review', $this->b_vars , true ) . cb1_get_template_part( 'booking-review-submit', $this->b_vars , true );
 
                 } // end if validated - days
 
@@ -779,7 +779,7 @@ public function get_booked_days_array( $item_id, $comments, $status= 'confirmed'
                             // PRINT: Booking review, Cancel Button
                             $message = cb_display_message( $msg, $this->b_vars );
 
-                            return $message . $message_comments . cb_get_template_part( 'booking-review-code', $this->b_vars , true ) . cb_get_template_part( 'booking-review', $this->b_vars , true ) . cb_get_template_part( 'booking-review-cancel', $this->b_vars , true );
+                            return $message . $message_comments . cb1_get_template_part( 'booking-review-code', $this->b_vars , true ) . cb1_get_template_part( 'booking-review', $this->b_vars , true ) . cb1_get_template_part( 'booking-review-cancel', $this->b_vars , true );
 
                         } else { // while pending, somebody else took the slot 
                             $string = __('Sorry, somebody else just booked this slot.', 'commons-booking' );
@@ -792,7 +792,7 @@ public function get_booked_days_array( $item_id, $comments, $status= 'confirmed'
 
                         // display cancel button only if currentdate <= booking end date
                         if ( date ('ymd', time() ) <= date ('ymd', $this->b_vars['date_end_timestamp'] ) ) {
-                            $cancel_button = cb_get_template_part( 'booking-review-cancel', $this->b_vars , true );
+                            $cancel_button = cb1_get_template_part( 'booking-review-cancel', $this->b_vars , true );
                         } else {
                             $cancel_button = '';
                         }
@@ -804,7 +804,7 @@ public function get_booked_days_array( $item_id, $comments, $status= 'confirmed'
                         }
 
                         // PRINT: Code, Booking review, Cancel Button
-                        return cb_get_template_part( 'user-bar', array(), true ) .cb_get_template_part( 'booking-review-code', $this->b_vars , true ) .  $comments . cb_get_template_part( 'booking-review', $this->b_vars , true ) . $cancel_button;
+                        return cb1_get_template_part( 'user-bar', array(), true ) .cb1_get_template_part( 'booking-review-code', $this->b_vars , true ) .  $comments . cb1_get_template_part( 'booking-review', $this->b_vars , true ) . $cancel_button;
 
 
                     } elseif ( $booking['status'] == 'confirmed' && !empty($_GET['cancel']) && $_GET['cancel'] == 1 ) {

--- a/public/cb-bookings/class-cb-data.php
+++ b/public/cb-bookings/class-cb-data.php
@@ -306,7 +306,7 @@ class CB_Data {
 
     $template_vars = $this->get_timeframe_array( $item_id );
     if ($template_vars) {
-      return cb_get_template_part( 'timeframes-full', $template_vars, true ); // include the template
+      return cb1_get_template_part( 'timeframes-full', $template_vars, true ); // include the template
     } else {
       return '<span class="">'. __( 'This item can´t be booked at the moment.', $this->prefix ) . '</span>';
     }
@@ -403,12 +403,12 @@ class CB_Data {
       'meta' => get_post_meta( $id )
       );
 
-    $item_content =  cb_get_template_part( 'item-list-item', $attributes, TRUE );
+    $item_content =  cb1_get_template_part( 'item-list-item', $attributes, TRUE );
 
     $timeframes = $this->get_timeframe_array( $id, $this->current_date, TRUE );
 
     if ( $timeframes ) {
-      $item_content .=  cb_get_template_part( 'item-list-timeframes-compact', $timeframes, TRUE );
+      $item_content .=  cb1_get_template_part( 'item-list-timeframes-compact', $timeframes, TRUE );
     } else {
       $item_content .= '<span class="">'. __( 'This item can´t be booked at the moment.', $this->prefix ) . '</span></div>';
     }
@@ -607,7 +607,7 @@ public function prepare_template_vars_timeframe ( $location, $timeframe ) {
       'target_url' => get_permalink( $this->target_url ),
       'plugin_slug' => $this->prefix
       );
-    return cb_get_template_part( 'calendar-bookingbar', $template_vars , true );
+    return cb1_get_template_part( 'calendar-bookingbar', $template_vars , true );
   }
 }
 ?>


### PR DESCRIPTION
in order to prevent errors when having commons booking <1.0 and commonsbooking >2.0 in parallel operation we have to rename the cb_get_template_part method.
see issue #186 